### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,16 +1,16 @@
 # Datatypes
 
-Cyclic  KEYWORD1
+Cyclic	KEYWORD1
 
 # Methods and Functions
 
-start   KEYWORD2
-stop    KEYWORD2
-reset   KEYWORD2
-reboot  KEYWORD2
-update  KEYWORD2
-time    KEYWORD2
-now     KEYWORD2
-last    KEYWORD2
-cycle   KEYWORD2
-cycles  KEYWORD2
+start	KEYWORD2
+stop	KEYWORD2
+reset	KEYWORD2
+reboot	KEYWORD2
+update	KEYWORD2
+time	KEYWORD2
+now	KEYWORD2
+last	KEYWORD2
+cycle	KEYWORD2
+cycles	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords